### PR TITLE
Allow package to be imported correctly

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Returns from a pool of 10m human-readable IDs",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "jsnext:main": "src/index.ts",
   "scripts": {
     "start": "tsc -w",
     "build": "rm -rf ./dist && tsc",


### PR DESCRIPTION
This field in the package.json was making it not possible to import the package.