### PR TITLE
docs: fix example; default import needs destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install human-id
 ## Usage
 
 ```js
-import humanId from 'human-id'
+import { humanId } from 'human-id'
 
 // RareGeckosJam
 humanId()


### PR DESCRIPTION
Fixes the example in the README, it does not work as-is.

Thanks for the package!