### PR TITLE
Upgrade to Typescript 6

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /.git
 /.idea
 /gitignore
+/node_modules
+/dist

--- a/index.ts
+++ b/index.ts
@@ -20,9 +20,6 @@ export interface Options {
 
 /**
  * Returns the human-id
- *
- * @param {Options|string|boolean} [options = {}]
- * @returns {string}
  */
 export function humanId(options: Options | string | boolean = {}): string {
 	if(typeof options === 'string') options = { separator: options }
@@ -49,9 +46,6 @@ export function humanId(options: Options | string | boolean = {}): string {
 
 /**
  * Returns the pool size for a set of options
- *
- * @param {Options} [options = {}]
- * @returns {number}
  */
 export function poolSize(options: Options = {}): number {
   const { adjectiveCount = 1, addAdverb = false } = options
@@ -60,9 +54,6 @@ export function poolSize(options: Options = {}): number {
 
 /**
  * Returns the max length for a set of options
- *
- * @param {Options} [options = {}]
- * @returns {number}
  */
 export function maxLength(options: Options = {}): number {
   const { adjectiveCount = 1, addAdverb = false, separator = '' } = options
@@ -76,9 +67,6 @@ export function maxLength(options: Options = {}): number {
 
 /**
  * Returns the min length for a set of options
- *
- * @param {Options} [options = {}]
- * @returns {number}
  */
 export function minLength(options: Options = {}): number {
   const { adjectiveCount = 1, addAdverb = false, separator = '' } = options

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "bin": "dist/cli.js",
+  "type": "module",
   "scripts": {
     "dev": "tsc -w",
     "build": "rm -rf ./dist && tsc",
@@ -27,6 +28,6 @@
     "url": "https://github.com/RienNeVaPlus/human-id/issues"
   },
   "devDependencies": {
-    "typescript": "^4.4.4"
+    "typescript": "^6.0.3"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
 	"compilerOptions": {
-		"lib": ["es7","dom"],
+		"lib": ["es2022","dom"],
 		/* Basic Options */
-		"target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-		"module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+		"target": "es2022",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+		"module": "es2022",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
 		// "lib": [],                             /* Specify library files to be included in the compilation. */
 		// "allowJs": true,                       /* Allow javascript files to be compiled. */
 		// "checkJs": true,                       /* Report errors in .js files. */
@@ -16,7 +16,6 @@
     "rootDir": ".",                            /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
 //		"rootDirs": ["./"],
 		// "composite": true,                     /* Enable project compilation */
-		 "removeComments": true,                /* Do not emit comments to output. */
 		// "noEmit": true,                        /* Do not emit outputs. */
 		// "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
 		// "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
@@ -39,14 +38,13 @@
 		"noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
 
 		/* Module Resolution Options */
-		"moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		"moduleResolution": "bundler",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
 		// "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
 		// "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
 		// "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
 		// "typeRoots": [],                       /* List of folders to include type definitions from. */
 		// "types": [],                           /* Type declaration files to be included in compilation. */
 		"allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-		"esModuleInterop": false,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
 		// "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
 		/* Source Map Options */


### PR DESCRIPTION
When `npm install`ing human id, my Typescript compiler started complaining about certain settings being deprecated. I suppose this is because Typescript is gearing up for a big jump to Typescript 7. 

<img width="1278" height="210" alt="{B7F35C76-9BE6-4676-BFBB-A91F1495B34E}" src="https://github.com/user-attachments/assets/90a1b697-3478-4d36-a4f7-2f6da127191f" />

So I figured I'd take a moment to update this library accordingly. This should be a semver major version bump, since it

- Updates to Typescript 6
- Updates the Typescript settings
- **Changes the output format to es modules, as is the recommended practice nowadays**

I tested this locally and it does work.

Small bonus: I changed the setting to preserve comments. Makes using the library more fun.

Before:
<img width="715" height="178" alt="{196DEEA8-490C-4A90-9792-27CD541D4A53}" src="https://github.com/user-attachments/assets/c8a9c4d8-a356-4f74-a0ab-4c4897212629" />

After: 
<img width="708" height="204" alt="{6092B80B-6FAD-449B-8200-FEF20EE95F2F}" src="https://github.com/user-attachments/assets/d48b19a0-e850-4114-9c67-52cdb6826dea" />

